### PR TITLE
Correct calculation of resolution for MMC-1xx series

### DIFF
--- a/micronixApp/src/MMC200Driver.cpp
+++ b/micronixApp/src/MMC200Driver.cpp
@@ -180,7 +180,9 @@ MMC200Axis::MMC200Axis(MMC200Controller *pC, int axisNo)
     model_ = -1;
   }
 
-  // Read the axis resolution (units = tens of picometers per full step)
+  // Read the axis resolution 
+  // for MMC-200, units = tens of picometers per full step
+  // for MMC-1xx, units = steps per micrometer, or steps per milli-degree
   sprintf(pC_->outString_, "%dREZ?", axisIndex_);
   status = pC_->writeReadController();
   if (status != asynSuccess)
@@ -199,12 +201,19 @@ MMC200Axis::MMC200Axis(MMC200Controller *pC, int axisNo)
   }
   else
   {
-    // The MMC-100 has a fixed number of microsteps
-    microSteps_ = 100;
+    // The MMC-1xx controllers don't use microsteps
+    microSteps_ = 1;
   }
   
-  // Calculate motor resolution (mm / microstep)
-  resolution_ = rez_ * 1e-8 / microSteps_;
+  // Calculate motor resolution (mm / microstep or deg / microstep)
+  if ( model_ == 200 )
+  {
+    resolution_ = rez_ * 1e-8 / microSteps_;
+  }
+  else
+  {
+    resolution_ = 1e-3 / rez_;
+  }
 
   // Read max velocity (needed for jog speed calculation)
   sprintf(pC_->outString_, "%dVMX?", axisIndex_);


### PR DESCRIPTION
The value obtained from the nREZ? query is in 10-picometer/full-step for the MMC-200, but for MMC-100, 103, and 110, it's in steps/micrometer or steps/milli-degree. And as far as I can tell, the MMC-1xx don't have microsteps.

This commit:
- corrects the calculation of resolution_ for MMC-1xx controllers
- sets microSteps_ to 1 for MMC-1xx controllers

See manuals:
[MMC-200](https://micronixusa.com/product/download/evPpvw/universal-document/Avj2vR/MMC-200%20Manual%20content%20Rev3.05.pdf) [MMC-110](https://micronixusa.com/product/download/jVWYnK/universal-document/WX0pXb/MMC-100%20Manual%20content%20Rev3.02.pdf)